### PR TITLE
fix: use atomic in the cache

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -26,6 +26,7 @@ import (
 	"unsafe"
 
 	"github.com/outcaste-io/ristretto/z"
+	"go.uber.org/atomic"
 )
 
 var (
@@ -64,7 +65,7 @@ type Cache struct {
 	// stop is used to stop the processItems goroutine.
 	stop chan struct{}
 	// indicates whether cache is closed.
-	isClosed bool
+	isClosed atomic.Bool
 	// cost calculates cost from a value.
 	cost func(value interface{}) int64
 	// ignoreInternalCost dictates whether to ignore the cost of internally storing
@@ -214,7 +215,7 @@ func NewCache(config *Config) (*Cache, error) {
 }
 
 func (c *Cache) Wait() {
-	if c == nil || c.isClosed {
+	if c == nil || c.isClosed.Load() {
 		return
 	}
 	wg := &sync.WaitGroup{}
@@ -227,7 +228,7 @@ func (c *Cache) Wait() {
 // value was found or not. The value can be nil and the boolean can be true at
 // the same time.
 func (c *Cache) Get(key interface{}) (interface{}, bool) {
-	if c == nil || c.isClosed || key == nil {
+	if c == nil || c.isClosed.Load() || key == nil {
 		return nil, false
 	}
 	keyHash, conflictHash := c.keyToHash(key)
@@ -270,7 +271,7 @@ func (c *Cache) SetIfPresent(key, value interface{}, cost int64) bool {
 
 func (c *Cache) setInternal(key, value interface{},
 	cost int64, ttl time.Duration, onlyUpdate bool) bool {
-	if c == nil || c.isClosed || key == nil {
+	if c == nil || c.isClosed.Load() || key == nil {
 		return false
 	}
 
@@ -326,7 +327,7 @@ func (c *Cache) setInternal(key, value interface{},
 
 // Del deletes the key-value item from the cache if it exists.
 func (c *Cache) Del(key interface{}) {
-	if c == nil || c.isClosed || key == nil {
+	if c == nil || c.isClosed.Load() || key == nil {
 		return
 	}
 	keyHash, conflictHash := c.keyToHash(key)
@@ -373,7 +374,7 @@ func (c *Cache) GetTTL(key interface{}) (time.Duration, bool) {
 
 // Close stops all goroutines and closes all channels.
 func (c *Cache) Close() {
-	if c == nil || c.isClosed {
+	if c == nil || c.isClosed.Load() {
 		return
 	}
 	c.Clear()
@@ -383,14 +384,14 @@ func (c *Cache) Close() {
 	close(c.stop)
 	close(c.setBuf)
 	c.policy.Close()
-	c.isClosed = true
+	c.isClosed.Store(true)
 }
 
 // Clear empties the hashmap and zeroes all policy counters. Note that this is
 // not an atomic operation (but that shouldn't be a problem as it's assumed that
 // Set/Get calls won't be occurring until after this).
 func (c *Cache) Clear() {
-	if c == nil || c.isClosed {
+	if c == nil || c.isClosed.Load() {
 		return
 	}
 	// Block until processItems goroutine is returned.

--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,6 @@ require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
+	go.uber.org/atomic v1.9.0 // indirect
 	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f
 )

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,11 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
+go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
Signed-off-by: Weizhen Wang <wangweizhen@pingcap.com>

we find the data race in the cache of ristretto when to test our cases.

```
==================
WARNING: DATA RACE
Write at 0x00c002c1a0d8 by goroutine 99:
  github.com/dgraph-io/ristretto.(*Cache).Close()
      /home/prow/go/pkg/mod/github.com/dgraph-io/ristretto@v0.1.0/cache.go:363 +0xe4
  github.com/pingcap/tidb/store/copr.(*Store).Close()
      /go/tidb/store/copr/store.go:97 +0x91
  github.com/pingcap/tidb/store/mockstore/mockstorage.(*mockStorage).Close()
      /go/tidb/store/mockstore/mockstorage/storage.go:116 +0x27
  github.com/pingcap/tidb/testkit.bootstrap.func1()
      /go/tidb/testkit/mockstore.go:57 +0x68
  runtime.deferreturn()
      /usr/local/go/src/runtime/panic.go:436 +0x32
  github.com/pingcap/failpoint.parseTerm()
      /home/prow/go/pkg/mod/github.com/pingcap/failpoint@v0.0.0-20220303073211-00fea37feb66/terms.go:149 +0x377
  github.com/pingcap/failpoint.parse()
      /home/prow/go/pkg/mod/github.com/pingcap/failpoint@v0.0.0-20220303073211-00fea37feb66/terms.go:126 +0xa8
  github.com/pingcap/failpoint.newTerms()
      /home/prow/go/pkg/mod/github.com/pingcap/failpoint@v0.0.0-20220303073211-00fea37feb66/terms.go:98 +0x50
  github.com/pingcap/failpoint.(*Failpoint).Enable()
      /home/prow/go/pkg/mod/github.com/pingcap/failpoint@v0.0.0-20220303073211-00fea37feb66/failpoint.go:54 +0x44
  github.com/pingcap/failpoint.(*Failpoints).Enable()
      /home/prow/go/pkg/mod/github.com/pingcap/failpoint@v0.0.0-20220303073211-00fea37feb66/failpoints.go:105 +0x276
  github.com/pingcap/failpoint.Enable()
      /home/prow/go/pkg/mod/github.com/pingcap/failpoint@v0.0.0-20220303073211-00fea37feb66/failpoints.go:225 +0x14f
  github.com/pingcap/tidb/executor/seqtest_test.TestParallelHashAggClose()
      /go/tidb/executor/seqtest/seq_executor_test.go:711 +0x150
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1486 +0x47
Previous read at 0x00c002c1a0d8 by goroutine 7:
  github.com/dgraph-io/ristretto.(*Cache).Get()
      /home/prow/go/pkg/mod/github.com/dgraph-io/ristretto@v0.1.0/cache.go:225 +0x4a
  github.com/pingcap/tidb/store/copr.(*coprCache).Get()
      /go/tidb/store/copr/coprocessor_cache.go:152 +0x84
  github.com/pingcap/tidb/store/copr.(*copIteratorWorker).handleTaskOnce()
      /go/tidb/store/copr/coprocessor.go:724 +0x744
  github.com/pingcap/tidb/store/copr.(*copIteratorWorker).handleTask()
      /go/tidb/store/copr/coprocessor.go:676 +0x1e5
  github.com/pingcap/tidb/store/copr.(*copIteratorWorker).run()
      /go/tidb/store/copr/coprocessor.go:418 +0x173
  github.com/pingcap/tidb/store/copr.(*copIterator).open.func1()
      /go/tidb/store/copr/coprocessor.go:450 +0x58
Goroutine 99 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1486 +0x724
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1839 +0x99
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1439 +0x213
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1837 +0x7e4
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1719 +0xa71
  go.uber.org/goleak.VerifyTestMain()
      /home/prow/go/pkg/mod/go.uber.org/goleak@v1.1.12/testmain.go:53 +0x59
  github.com/pingcap/tidb/executor/seqtest.TestMain()
      /go/tidb/executor/seqtest/main_test.go:37 +0x430
  main.main()
      _testmain.go:125 +0x317
Goroutine 7 (finished) created at:
  github.com/pingcap/tidb/store/copr.(*copIterator).open()
      /go/tidb/store/copr/coprocessor.go:450 +0xc4
  github.com/pingcap/tidb/store/copr.(*CopClient).Send()
      /go/tidb/store/copr/coprocessor.go:143 +0x10c9
  github.com/pingcap/tidb/distsql.Select()
      /go/tidb/distsql/distsql.go:101 +0x8c3
  github.com/pingcap/tidb/distsql.SelectWithRuntimeStats()
      /go/tidb/distsql/distsql.go:150 +0xbb
  github.com/pingcap/tidb/executor.selectResultHook.SelectResult()
      /go/tidb/executor/table_reader.go:53 +0x1c5
  github.com/pingcap/tidb/executor.(*TableReaderExecutor).buildResp()
      /go/tidb/executor/table_reader.go:310 +0x69d
  github.com/pingcap/tidb/executor.(*TableReaderExecutor).Open()
      /go/tidb/executor/table_reader.go:210 +0x13f5
  github.com/pingcap/tidb/executor.(*baseExecutor).Open()
      /go/tidb/executor/executor.go:185 +0x6a9
  github.com/pingcap/tidb/executor.(*HashAggExec).Open()
      /go/tidb/executor/aggregate.go:309 +0xe6
  github.com/pingcap/tidb/executor.(*ExecStmt).Exec()
      /go/tidb/executor/adapter.go:407 +0x7f8
  github.com/pingcap/tidb/session.runStmt()
      /go/tidb/session/session.go:2017 +0x6cb
  github.com/pingcap/tidb/session.(*session).ExecuteStmt()
      /go/tidb/session/session.go:1894 +0xd3a
  github.com/pingcap/tidb/session.(*session).Execute()
      /go/tidb/session/session.go:1534 +0x478
  github.com/pingcap/tidb/executor/seqtest_test.TestParallelHashAggClose()
      /go/tidb/executor/seqtest/seq_executor_test.go:716 +0x21b
  github.com/pingcap/failpoint.parseTerm()
      /home/prow/go/pkg/mod/github.com/pingcap/failpoint@v0.0.0-20220303073211-00fea37feb66/terms.go:149 +0x377
  github.com/pingcap/failpoint.parse()
      /home/prow/go/pkg/mod/github.com/pingcap/failpoint@v0.0.0-20220303073211-00fea37feb66/terms.go:126 +0xa8
  github.com/pingcap/failpoint.newTerms()
      /home/prow/go/pkg/mod/github.com/pingcap/failpoint@v0.0.0-20220303073211-00fea37feb66/terms.go:98 +0x50
  github.com/pingcap/failpoint.(*Failpoint).Enable()
      /home/prow/go/pkg/mod/github.com/pingcap/failpoint@v0.0.0-20220303073211-00fea37feb66/failpoint.go:54 +0x44
  github.com/pingcap/failpoint.(*Failpoints).Enable()
      /home/prow/go/pkg/mod/github.com/pingcap/failpoint@v0.0.0-20220303073211-00fea37feb66/failpoints.go:105 +0x276
  github.com/pingcap/failpoint.Enable()
      /home/prow/go/pkg/mod/github.com/pingcap/failpoint@v0.0.0-20220303073211-00fea37feb66/failpoints.go:225 +0x14f
  github.com/pingcap/tidb/executor/seqtest_test.TestParallelHashAggClose()
      /go/tidb/executor/seqtest/seq_executor_test.go:711 +0x150
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1486 +0x47
================== 

```

ref  https://github.com/pingcap/tidb/issues/33649

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/outcaste-io/ristretto/2)
<!-- Reviewable:end -->
