### PR TITLE
z,contrib: remove github.com/golang/glog

### DIFF
--- a/contrib/memtest/main.go
+++ b/contrib/memtest/main.go
@@ -31,9 +31,8 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/outcaste-io/ristretto/z"
 	"github.com/dustin/go-humanize"
-	"github.com/golang/glog"
+	"github.com/outcaste-io/ristretto/z"
 )
 
 type S struct {
@@ -67,7 +66,7 @@ func newS(sz int) *S {
 	s.val = Calloc(sz)
 	copy(s.val, fill)
 	if s.next != nil {
-		glog.Fatalf("news.next must be nil: %p", s.next)
+		panic(fmt.Sprintf("news.next must be nil: %p", s.next))
 	}
 	return s
 }
@@ -87,7 +86,7 @@ func (s *S) allocateNext(sz int) {
 
 func (s *S) deallocNext() {
 	if s.next == nil {
-		glog.Fatal("next should not be nil")
+		panic("next should not be nil")
 	}
 	next := s.next
 	s.next = next.next
@@ -161,13 +160,13 @@ func main() {
 	}()
 	go func() {
 		if err := http.ListenAndServe("0.0.0.0:8080", nil); err != nil {
-			glog.Fatalf("Error: %v", err)
+			panic(fmt.Sprintf("Error: %v", err))
 		}
 	}()
 
 	viaLL()
 	if left := NumAllocBytes(); left != 0 {
-		glog.Fatalf("Unable to deallocate all memory: %v\n", left)
+		panic(fmt.Sprintf("Unable to deallocate all memory: %v\n", left))
 	}
 	runtime.GC()
 	fmt.Println("Done. Reduced to zero memory usage.")

--- a/contrib/memtest/nojemalloc.go
+++ b/contrib/memtest/nojemalloc.go
@@ -8,8 +8,6 @@ import (
 	"reflect"
 	"sync/atomic"
 	"unsafe"
-
-	"github.com/golang/glog"
 )
 
 func Calloc(size int) []byte {
@@ -40,7 +38,3 @@ func Free(bs []byte) {
 func NumAllocBytes() int64 { return atomic.LoadInt64(&numbytes) }
 
 func check() {}
-
-func init() {
-	glog.Infof("USING CALLOC")
-}

--- a/contrib/memtest/withjemalloc.go
+++ b/contrib/memtest/withjemalloc.go
@@ -3,8 +3,9 @@
 package main
 
 import (
+	"os"
+
 	"github.com/outcaste-io/ristretto/z"
-	"github.com/golang/glog"
 )
 
 func Calloc(size int) []byte { return z.Calloc(size, "memtest") }
@@ -13,14 +14,11 @@ func NumAllocBytes() int64   { return z.NumAllocBytes() }
 
 func check() {
 	if buf := z.CallocNoRef(1, "memtest"); len(buf) == 0 {
-		glog.Fatalf("Not using manual memory management. Compile with jemalloc.")
+		panic("Not using manual memory management. Compile with jemalloc.")
+		os.Exit(1)
 	} else {
 		z.Free(buf)
 	}
 
 	z.StatsPrint()
-}
-
-func init() {
-	glog.Infof("USING JEMALLOC")
 }

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,10 @@ go 1.12
 
 require (
 	github.com/cespare/xxhash/v2 v2.1.1
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2
 	github.com/dustin/go-humanize v1.0.0
-	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
-	go.uber.org/atomic v1.9.0 // indirect
+	go.uber.org/atomic v1.9.0
 	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f
 )

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,6 @@ github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczC
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
-github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/z/bbloom.go
+++ b/z/bbloom.go
@@ -25,8 +25,6 @@ import (
 	"encoding/json"
 	"math"
 	"unsafe"
-
-	"github.com/golang/glog"
 )
 
 // helper
@@ -60,7 +58,7 @@ func NewBloomFilter(params ...float64) (bloomfilter *Bloom) {
 			entries, locs = uint64(params[0]), uint64(params[1])
 		}
 	} else {
-		glog.Fatal("usage: New(float64(number_of_entries), float64(number_of_hashlocations))" +
+		fatal("usage: New(float64(number_of_entries), float64(number_of_hashlocations))" +
 			" i.e. New(float64(1000), float64(3)) or New(float64(number_of_entries)," +
 			" float64(number_of_hashlocations)) i.e. New(float64(1000), float64(0.03))")
 	}
@@ -205,7 +203,7 @@ func (bl Bloom) JSONMarshal() []byte {
 	}
 	data, err := json.Marshal(bloomImEx)
 	if err != nil {
-		glog.Fatal("json.Marshal failed: ", err)
+		fatal("json.Marshal failed: ", err)
 	}
 	return data
 }

--- a/z/buffer.go
+++ b/z/buffer.go
@@ -24,7 +24,6 @@ import (
 	"sort"
 	"sync/atomic"
 
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
 )
 
@@ -346,12 +345,12 @@ func (s *sortHelper) sortSmall(start, end int) {
 
 func assert(b bool) {
 	if !b {
-		glog.Fatalf("%+v", errors.Errorf("Assertion failure"))
+		fatalf("%+v", errors.Errorf("Assertion failure"))
 	}
 }
 func check(err error) {
 	if err != nil {
-		glog.Fatalf("%+v", err)
+		fatalf("%+v", err)
 	}
 }
 func check2(_ interface{}, err error) {

--- a/z/flags.go
+++ b/z/flags.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
 )
 
@@ -109,7 +108,7 @@ type SuperFlag struct {
 func NewSuperFlag(flag string) *SuperFlag {
 	sf, err := newSuperFlagImpl(flag)
 	if err != nil {
-		glog.Fatal(err)
+		fatal(err)
 	}
 	return sf
 }
@@ -136,7 +135,7 @@ func (sf *SuperFlag) String() string {
 func (sf *SuperFlag) MergeAndCheckDefault(flag string) *SuperFlag {
 	sf, err := sf.MergeWithDefault(flag)
 	if err != nil {
-		glog.Fatal(err)
+		fatal(err)
 	}
 	return sf
 }
@@ -207,7 +206,7 @@ func (sf *SuperFlag) GetBool(opt string) bool {
 		err = errors.Wrapf(err,
 			"Unable to parse %s as bool for key: %s. Options: %s\n",
 			val, opt, sf)
-		glog.Fatalf("%+v", err)
+		fatalf("%+v", err)
 	}
 	return b
 }
@@ -222,7 +221,7 @@ func (sf *SuperFlag) GetFloat64(opt string) float64 {
 		err = errors.Wrapf(err,
 			"Unable to parse %s as float64 for key: %s. Options: %s\n",
 			val, opt, sf)
-		glog.Fatalf("%+v", err)
+		fatalf("%+v", err)
 	}
 	return f
 }
@@ -237,7 +236,7 @@ func (sf *SuperFlag) GetInt64(opt string) int64 {
 		err = errors.Wrapf(err,
 			"Unable to parse %s as int64 for key: %s. Options: %s\n",
 			val, opt, sf)
-		glog.Fatalf("%+v", err)
+		fatalf("%+v", err)
 	}
 	return i
 }
@@ -252,7 +251,7 @@ func (sf *SuperFlag) GetUint64(opt string) uint64 {
 		err = errors.Wrapf(err,
 			"Unable to parse %s as uint64 for key: %s. Options: %s\n",
 			val, opt, sf)
-		glog.Fatalf("%+v", err)
+		fatalf("%+v", err)
 	}
 	return u
 }
@@ -267,7 +266,7 @@ func (sf *SuperFlag) GetUint32(opt string) uint32 {
 		err = errors.Wrapf(err,
 			"Unable to parse %s as uint32 for key: %s. Options: %s\n",
 			val, opt, sf)
-		glog.Fatalf("%+v", err)
+		fatalf("%+v", err)
 	}
 	return uint32(u)
 }
@@ -283,7 +282,7 @@ func (sf *SuperFlag) GetPath(opt string) string {
 	p := sf.GetString(opt)
 	path, err := expandPath(p)
 	if err != nil {
-		glog.Fatalf("Failed to get path: %+v", err)
+		fatalf("Failed to get path: %+v", err)
 	}
 	return path
 }

--- a/z/z.go
+++ b/z/z.go
@@ -18,6 +18,8 @@ package z
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"sync"
 
 	"github.com/cespare/xxhash/v2"
@@ -148,4 +150,14 @@ func ZeroOut(dst []byte, start, end int) {
 	// for i := range b {
 	// 	b[i] = 0x0
 	// }
+}
+
+func fatal(args ...interface{}) {
+	defer os.Exit(1)
+	panic(fmt.Sprint(args...))
+}
+
+func fatalf(format string, args ...interface{}) {
+	defer os.Exit(1)
+	panic(fmt.Sprintf(format, args...))
 }


### PR DESCRIPTION
Currently ristretto depends on glog. The problem with glog is that it
defines global flags, which is not a nice behavior for libraries.

The code called glog.Fatal, which can be replaced with a regular panic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/outcaste-io/ristretto/3)
<!-- Reviewable:end -->
