### PR TITLE
Add a test to ensure that calling Set after Close does not panic

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -997,3 +997,51 @@ func TestCacheWithTTL(t *testing.T) {
 		})
 	}
 }
+
+func TestConcurrentSetAfterClose(t *testing.T) {
+	c, err := NewCache(&Config{
+		NumCounters:        100,
+		MaxCost:            10,
+		IgnoreInternalCost: true,
+		BufferItems:        64,
+		Metrics:            true,
+	})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	done := make(chan struct{})
+
+	// Spin up a bunch of goroutines that simply call Set over and over.
+	for i := 0; i <= 200; i += 5 {
+		wg.Add(1)
+		go (func(duration int) {
+			wg.Done()
+
+			tc := time.Tick(time.Duration(duration) * time.Millisecond)
+		outer:
+			for {
+				select {
+				case <-tc:
+					c.Set("somekey", duration, 1)
+
+				case <-done:
+					break outer
+				}
+			}
+		})(i)
+	}
+
+	wg.Wait()
+
+	// Wait some time so Set can run a few times.
+	tc := time.Tick(50 * time.Millisecond)
+	<-tc
+
+	// Run close to ensure nothing panics.
+	c.Close()
+
+	// Wait some more time so Set can run a few additional times.
+	tcd := time.Tick(250 * time.Millisecond)
+	<-tcd
+	close(done)
+}

--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,5 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/atomic v1.9.0
-	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f
+	golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b
 )

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
-golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
-golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b h1:2n253B2r0pYSmEV+UNCQoPfU/FiaizQEK5Gu4Bq4JE8=
+golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=


### PR DESCRIPTION
On a previous version of ristretto, we experienced a panic occasionally due to calling Set after Close resulting in a write to the closed `setBuf` channel. We originally wrote this test as part of a fix on a forked version of Ristretto. Thankfully, on HEAD, this test is no longer failing, so we are submitting it to act as a guard against any regressions in the future.

NOTE: The update to `golang.org/x/sys` also fixes a build issue with Golang 1.18 on Darwin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/outcaste-io/ristretto/5)
<!-- Reviewable:end -->
